### PR TITLE
Using class

### DIFF
--- a/approach1.F90
+++ b/approach1.F90
@@ -1,7 +1,7 @@
 module my_approach1
   use my_data1
 
-  class(*), allocatable, target :: grid
+  class(grid_base), allocatable, target :: grid
 
 contains
 

--- a/approach2.F90
+++ b/approach2.F90
@@ -3,7 +3,7 @@ module my_approach2
 
   type(grid_r4), allocatable, target :: gr_4
   type(grid_r8), allocatable, target :: gr_8
-  class(*), pointer :: grid
+  class(grid_base), pointer :: grid
 
 contains
 
@@ -50,6 +50,7 @@ contains
     type is (grid_r8)
       deallocate(gr_8)
     end select
+    if (associated(grid)) nullify(grid)
   end subroutine grid_end
 
 end module my_approach2

--- a/data1.F90
+++ b/data1.F90
@@ -13,6 +13,6 @@ module my_data1
   end type grid_r8
 
   private
-  public :: grid_r4, grid_r8
+  public :: grid_r4, grid_r8, grid_base
 
 end module my_data1

--- a/main.F90
+++ b/main.F90
@@ -1,5 +1,5 @@
 program main
-  use my_approach3
+  use my_approach1
 
   real(4), dimension(2) :: a
   a(1) = 1.0


### PR DESCRIPTION
This PR modifies the code to use `class (grid_base)` instead of a `class(*)` variable.